### PR TITLE
Reorganización del texto dentro de bloques de código para no superar los 80 caracteres

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,17 @@ Para especificar como las acciones transforman el árbol de estado, usas *reduce
 import { createStore } from 'redux';
 
 /**
- * Esto es un reducer, una función pura con el formato (state, action) => newState.
- * Describe como una acción transforma el estado en el nuevo estado.
+ * Esto es un reducer, una función pura con el formato
+ * (state, action) => newState. Describe como una acción transforma el estado
+ * en el nuevo estado.
  *
- * La forma del estado depende de tí: puede ser un primitivo, un array, un objeto, o incluso una estructura de datos de Immutable.js. La única parte importante es que no debes modificar el objeto del estado, en vez de eso devolver una nuevo objeto si el estado cambió.
+ * La forma del estado depende de tí: puede ser un primitivo, un array, un
+ * objeto, o incluso una estructura de datos de Immutable.js. La única parte
+ * importante es que no debes modificar el objeto del estado, en vez de eso
+ * devolver una nuevo objeto si el estado cambió.
  *
- * En este ejemplo, usamos `switch` y strings, pero puedes usar cualquier forma que desees si tiene sentido para tu proyecto.
+ * En este ejemplo, usamos `switch` y strings, pero puedes usar cualquier forma
+ * que desees si tiene sentido para tu proyecto.
  */
 function counter(state = 0, action) {
   switch (action.type) {
@@ -77,13 +82,15 @@ function counter(state = 0, action) {
 // Su API es { subscribe, dispatch, getState }.
 let store = createStore(counter);
 
-// Puedes suscribirte manualmente a los cambios, o conectar tu vista directamente
+// Puedes suscribirte manualmente a los cambios, o conectar tu vista
+// directamente
 store.subscribe(() => {
   console.log(store.getState())
 });
 
 // La única forma de modificar el estado interno es despachando acciones.
-// Las acciones pueden ser serializadas, registradas o almacenadas luego para volver a ejecutarlas.
+// Las acciones pueden ser serializadas, registradas o almacenadas luego para
+// volver a ejecutarlas.
 store.dispatch({ type: 'INCREMENT' });
 // 1
 store.dispatch({ type: 'INCREMENT' });


### PR DESCRIPTION
Al leer la documentación se me hacía muy complicado leerlo teniendo que desplazar todo el código horizontalmente. No sé si lo teníais así por algún motivo, pero me parece bastante más cómodo de leer con el formato que paso con el PR.

Ahí lo dejo, por si os parece bien unirlo a vuestro master, o si queréis modificar el formato antes de unir.

Gracias por la traducción! :+1:  