### PR TITLE
React.PropTypes has moved into a different package

### DIFF
--- a/docs/basico/uso-con-react.md
+++ b/docs/basico/uso-con-react.md
@@ -115,7 +115,8 @@ Todos estos son componentes normales de React, por lo que no los examinaremos en
 #### `components/Todo.js`
 
 ```js
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types';
 
 const Todo = ({ onClick, completed, text }) => (
   <li
@@ -140,7 +141,8 @@ export default Todo
 #### `components/TodoList.js`
 
 ```js
-import React, { PropTypes } from 'react'
+import React from 'react';
+import PropTypes from 'prop-types';
 import Todo from './Todo'
 
 const TodoList = ({ todos, onTodoClick }) => (
@@ -170,7 +172,8 @@ export default TodoList
 #### `components/Link.js`
 
 ```js
-import React, { PropTypes } from 'react'
+import Reac from 'react';
+import PropTypes from 'prop-types';
 
 const Link = ({ active, children, onClick }) => {
   if (active) {


### PR DESCRIPTION
React.PropTypes has moved into a different package since React v15.5. you can use the prop-types library instead.
for more info https://reactjs.org/docs/typechecking-with-proptypes.html